### PR TITLE
Clean up solutions page as well as the javascript

### DIFF
--- a/_partials/solution-partial-unifiedpush.html.slim
+++ b/_partials/solution-partial-unifiedpush.html.slim
@@ -1,17 +1,16 @@
 .row
-  .large-12.columns
-    | The Unified Push server allows developers to send native push messages to Apple's Push Notification Service (APNS) and Google's Cloud Messaging (GCM).
-      It features a built-in administration console that makes it easy for developers to create and manage push related aspects of their applications for any mobile development environment.
-      Includes client SDKs (iOS, Android, & Cordova), and a REST based sender service with an available Java sender library.
-      For more details and links see the 
-    a href="https://www.openshift.com/xpaas" OpenShift xPaaS page
-    |. 
+  .large-10.columns
+    p The Unified Push server allows developers to send native push messages to Apple's Push Notification Service (APNS) and Google's Cloud Messaging (GCM). It features a built-in administration console that makes it easy for developers to create and manage push related aspects of their applications for any mobile development environment. Includes client SDKs (iOS, Android, & Cordova), and a REST based sender service with an available Java sender library.
+    p
+      | For more details and links see the 
+      a href="https://www.openshift.com/xpaas" OpenShift xPaaS page
+      | . 
     .row
       .large-18.columns
         .widget
           a.button.shadow.large(href="https://www.openshift.com/quickstarts/jboss-unifiedpush")
             | Try it on OpenShift
-  .large-12.columns
+  .large-14.columns
     = video_player(video("https://www.youtube.com/watch?v=ZFZlphKlGqM"))
 .row
   .large-24.columns
@@ -23,26 +22,40 @@
       .large-24.columns
         img src=cdn(site.base_url + "/images/solutions/unifiedpush/overview-image.png")
         
-  .large-24.columns
+  .large-24.columns.unifiedpush-downloads
     h3.divider Downloads and Documentation
     .row
       .large-12.columns
-        h4 Client Documentation
-        | This documentation covers the client API for the JBoss Unified Push server.
-        a href="https://www.jboss.org/download-manager/file/jboss-unified-push-1.0.0.Beta1-clients-doc.zip" Download
-        h4 Server Documentation
-        | This PDF documentation covers the installation and administration of a JBoss Unified Push server.
-        a href="http://docs.jboss.org/unifiedpush/unifiedpush.pdf" Download
-        h4 Quickstarts
-        | The JBoss Unified Push quickstarts are ready-to-assemble applications, provided in a variety of mobile API formats.
-        a href="https://www.jboss.org/download-manager/file/jboss-unified-push-1.0.0.Beta1-quickstarts.zip" Download
+        h4.divider Client Documentation
+        p This documentation covers the client API for the JBoss Unified Push server.
+        a.download href="https://www.jboss.org/download-manager/file/jboss-unified-push-1.0.0.Beta1-clients-doc.zip"
+          i.fa.fa-download
+          |  Download
+
+        h4.divider Server Documentation
+        p This PDF documentation covers the installation and administration of a JBoss Unified Push server.
+        a.download href="http://docs.jboss.org/unifiedpush/unifiedpush.pdf"
+          i.fa.fa-download
+          |  Download
+
+        h4.divider Quickstarts
+        p The JBoss Unified Push quickstarts are ready-to-assemble applications, provided in a variety of mobile API formats.
+        a.download href="https://www.jboss.org/download-manager/file/jboss-unified-push-1.0.0.Beta1-quickstarts.zip"
+          i.fa.fa-download
+          |  Download
+
       .large-12.columns
-        h4 Client and Sender SDKs
-        | This archive contains the JBoss Unified Push client libraries. 
-          Each library is ready-to-use and provides functionality for developing client and server applications that interface with the Unified Push Server.
-        a href="https://www.jboss.org/download-manager/file/jboss-unified-push-1.0.0.Beta1-clients.zip" Download
-        h4 Maven Repository
-        | This archive contains JBoss Unified Push Maven repository artifacts.
-        a href="https://www.jboss.org/download-manager/file/jboss-unified-push-1.0.0.Beta1-maven-repository.zip" Download
+        h4.divider Client and Sender SDKs
+        p This archive contains the JBoss Unified Push client libraries. Each library is ready-to-use and provides functionality for developing client and server applications that interface with the Unified Push Server.
+        a.download href="https://www.jboss.org/download-manager/file/jboss-unified-push-1.0.0.Beta1-clients.zip"
+          i.fa.fa-download
+          |  Download
+
+        h4.divider Maven Repository
+        p This archive contains JBoss Unified Push Maven repository artifacts.
+        a.download href="https://www.jboss.org/download-manager/file/jboss-unified-push-1.0.0.Beta1-maven-repository.zip"
+          i.fa.fa-download
+          |  Download
+
 
         

--- a/stylesheets/_solutions.scss
+++ b/stylesheets/_solutions.scss
@@ -119,6 +119,9 @@ $arrow-size : 20px;
   .solution-meta {
     margin: 0;
     font-weight: 600;
+    &:last-of-type {
+      margin-bottom: 1.25rem;
+    }
   }
   .slide {
     img {
@@ -253,6 +256,19 @@ blockquote.speech-bubble {
     width:250px;
     float: right;
     margin-top: -20px;
+  }
+}
+
+.unifiedpush-downloads {
+  h4.divider {
+    margin-top: 0;
+    margin-bottom: 10px;
+  }
+  a.download {
+    top: -0.5rem;
+    position: relative;
+    display: block;
+    text-align: right;
   }
 }
 


### PR DESCRIPTION
Okay - a few things:
1.  The layout for the solutions page is now much nicer for the docker images
2.  The toggling of the javascript now works

There is an issue with the build where the solutions page is getting the solutions javascript is being injected 4 times, which is why we were having the slide up/down issue - so that needs to be fixed. I suspect its because we are using partials but the "extra" javascript is defined in solutions-base.html.slim on line 7 
